### PR TITLE
Specify eval.processes in GymMicrorts example

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ xvfb-run -a poetry run python enn_zoo/train.py \
     eval.capture_videos=True \
     eval.interval=300000 \
     eval.steps=2000 \
-    eval.num_envs=1
+    eval.num_envs=1 \
+    eval.processes=1
 ```
 
 Here is a [tracked Gym-µRTS experiment](https://wandb.ai/entity-neural-network/enn-ppo/runs/1vpdd0cm?workspace=user-costa-huang), which has a trained agent that behaves as follows:


### PR DESCRIPTION
Otherwise, it tries to use the rollout default 4 processes, which is too many for only 1 eval env:
```
Traceback (most recent call last):
  File "/home/ubuntu/enn-zoo/enn_zoo/train.py", line 111, in <module>
    main()
  File "/home/ubuntu/miniconda3/envs/enn-zoo/lib/python3.9/site-packages/hyperstate/command.py", line 120, in _f
    return f(sm)
  File "/home/ubuntu/enn-zoo/enn_zoo/train.py", line 100, in main
    train(
  File "/home/ubuntu/miniconda3/envs/enn-zoo/lib/python3.9/site-packages/enn_trainer/train.py", line 353, in train
    _run_eval()
  File "/home/ubuntu/miniconda3/envs/enn-zoo/lib/python3.9/site-packages/enn_trainer/train.py", line 325, in _run_eval
    run_eval(
  File "/home/ubuntu/miniconda3/envs/enn-zoo/lib/python3.9/site-packages/enn_trainer/eval.py", line 40, in run_eval
    envs: VecEnv = create_env(
  File "/home/ubuntu/miniconda3/envs/enn-zoo/lib/python3.9/site-packages/enn_trainer/train.py", line 87, in _create_env
    return ParallelEnvList(create_env, num_envs, processes)
  File "/home/ubuntu/miniconda3/envs/enn-zoo/lib/python3.9/site-packages/entity_gym/env/parallel_env_list.py", line 115, in __init__
    assert (
AssertionError: The required number of environments can not be equally split into the number of specified processes.
```